### PR TITLE
Add instagram and twitter widgets to zoo show page.

### DIFF
--- a/public/ng-views/zoo.show.html
+++ b/public/ng-views/zoo.show.html
@@ -22,3 +22,11 @@
 <p>{{ZooShowVM.zoo.hours_of_op}}</p>
 <p>{{ZooShowVM.zoo.location}}</p>
 <p>{{ZooShowVM.zoo.transpo_info}}</p>
+
+<!-- SnapWidget -->
+<script src="http://snapwidget.com/js/snapwidget.js"></script>
+<iframe src="http://snapwidget.com/in/?u=c21pdGhzb25pYW56b298aW58MTI1fDN8M3x8bm98NXxub25lfG9uU3RhcnR8eWVzfHllcw==&ve=050416" title="Instagram Widget" class="snapwidget-widget" allowTransparency="true" frameborder="0" scrolling="no" style="border:none; overflow:hidden; width:100%;"></iframe>
+
+<!-- Twitter Widgets -->
+<a class="twitter-timeline" href="https://twitter.com/NationalZoo" data-widget-id="717536372853182464">Tweets by @NationalZoo</a>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>


### PR DESCRIPTION
Hi Guys,

I wanted to show you how we can pretty easily embed instagram and twitter content into our page! On [snapwidget](http://snapwidget.com/) we can easily create widgets for any username or hashtag we want.

An idea for having different instagram content to show up depending on the page:
- Add an `instagram_url` attribute to our animals and put the url portion of our widgets there
- Place the following code into our animals show pages:
```
<script src="http://snapwidget.com/js/snapwidget.js"></script>
<iframe src="{{MammalShowVM.mammal.instagram_url}}" title="Instagram Widget" class="snapwidget-widget" allowTransparency="true" frameborder="0" scrolling="no" style="border:none; overflow:hidden; width:100%;"></iframe>
```
What do you think??